### PR TITLE
Add an exception to handle missing item errors

### DIFF
--- a/src/main/java/seedu/manager/command/RemoveCommand.java
+++ b/src/main/java/seedu/manager/command/RemoveCommand.java
@@ -1,5 +1,7 @@
 package seedu.manager.command;
 
+import seedu.manager.exception.ItemNotFoundException;
+
 /**
  * Represents a command to remove an event from the event list.
  * The remove command will search for an event by its name and remove it if found.
@@ -7,7 +9,6 @@ package seedu.manager.command;
 public class RemoveCommand extends Command {
     public static final String COMMAND_WORD = "remove";
     private static final String REMOVE_SUCCESS = "Removed successfully";
-    private static final String REMOVE_FAILURE = "Not found";
     protected String eventName;
     protected String participantName;
 
@@ -23,12 +24,12 @@ public class RemoveCommand extends Command {
     /**
      * Constructs a RemoveCommand object with the specified event name.
      *
-     * @param eventName The name of the event the participant is to be removed from.
      * @param participantName The name of the participant to be removed.
+     * @param eventName       The name of the event the participant is to be removed from.
      */
-    public RemoveCommand(String eventName, String participantName) {
-        this.eventName = eventName;
+    public RemoveCommand(String participantName, String eventName) {
         this.participantName = participantName;
+        this.eventName = eventName;
     }
 
     /**
@@ -46,18 +47,16 @@ public class RemoveCommand extends Command {
      */
     @Override
     public CommandOutput execute() {
-        boolean isRemoved;
+        try {
+            if (participantName == null) {
+                eventList.removeEvent(this.eventName);
+            } else {
+                eventList.removeParticipantFromEvent(this.participantName, this.eventName);
+            }
 
-        if (participantName == null) {
-            isRemoved = this.eventList.removeEvent(this.eventName);
-        } else {
-            isRemoved = this.eventList.removeParticipantFromEvent(this.participantName, this.eventName);
-        }
-
-        if (isRemoved) {
             return new CommandOutput(REMOVE_SUCCESS, false);
-        } else {
-            return new CommandOutput(REMOVE_FAILURE, false);
+        } catch (ItemNotFoundException exception) {
+            return new CommandOutput(exception.getMessage(), false);
         }
     }
 }

--- a/src/main/java/seedu/manager/command/ViewCommand.java
+++ b/src/main/java/seedu/manager/command/ViewCommand.java
@@ -1,6 +1,7 @@
 package seedu.manager.command;
 
 import seedu.manager.event.Event;
+import seedu.manager.exception.ItemNotFoundException;
 
 /**
  * Represents a command to view the list of participants in an event.
@@ -27,23 +28,20 @@ public class ViewCommand extends Command{
      * @return The command output with a list message
      */
     public CommandOutput execute() {
-        Event event = null;
-        for (int i = 0; i < eventList.getListSize(); i++) {
-            if (eventList.getEvent(i).getEventName().equals(eventName)) {
-                event = eventList.getEvent(i);
+        try {
+            Event eventToView = eventList.getEventByName(this.eventName);
+
+            StringBuilder outputMessage = new StringBuilder(
+                    String.format(VIEW_MESSAGE, eventToView.getParticipantCount(), eventName) + "\n");
+            int count = 1;
+            for (String participant : eventToView.getParticipantList()) {
+                outputMessage.append(String.format("%d. %s\n", count, participant));
+                count++;
             }
+
+            return new CommandOutput(outputMessage.toString(), false);
+        } catch (ItemNotFoundException exception) {
+            return new CommandOutput(exception.getMessage(), false);
         }
-
-        //to handle errors in the future
-
-        StringBuilder outputMessage = new StringBuilder(
-                String.format(VIEW_MESSAGE, event.getParticipantCount(), eventName) + "\n");
-        int count = 1;
-        for (String participant : event.getParticipantList()) {
-            outputMessage.append(String.format("%d. %s\n", count , participant));
-            count++;
-        }
-
-        return new CommandOutput(outputMessage.toString(), false);
     }
 }

--- a/src/main/java/seedu/manager/event/Event.java
+++ b/src/main/java/seedu/manager/event/Event.java
@@ -1,5 +1,7 @@
 package seedu.manager.event;
 
+import seedu.manager.exception.ItemNotFoundException;
+
 import java.util.ArrayList;
 
 /**
@@ -7,6 +9,8 @@ import java.util.ArrayList;
  * It provides methods to access and modify the time and venue of the event.
  */
 public class Event {
+    private static final String MISSING_PARTICIPANT_MESSAGE = "Participant not found!";
+
     protected ArrayList<String> participantList;
     private final String eventName;
     private String eventTime;
@@ -50,17 +54,19 @@ public class Event {
      *
      * <p>
      * This method attempts to remove the specified participant from the list of
-     * participants associated with the event. It returns {@code true} if the
-     * participant was successfully removed, and {@code false} if the participant
-     * was not found in the list.
+     * participants associated with the event. It throws an {@link ItemNotFoundException}
+     * if the participant was not found in the list.
      * </p>
      *
      * @param participantName the name of the participant to be removed from the list.
-     * @return {@code true} if the participant was successfully removed;
-     *         {@code false} if the participant was not found in the list.
+     * @throws ItemNotFoundException if the participant was not found in the list.
      */
-    public boolean removeParticipant(String participantName) {
-        return this.participantList.remove(participantName);
+    public void removeParticipant(String participantName) throws ItemNotFoundException {
+        boolean isRemoved = this.participantList.remove(participantName);
+
+        if (!isRemoved) {
+            throw new ItemNotFoundException(MISSING_PARTICIPANT_MESSAGE);
+        }
     }
 
     /**

--- a/src/main/java/seedu/manager/event/EventList.java
+++ b/src/main/java/seedu/manager/event/EventList.java
@@ -1,5 +1,7 @@
 package seedu.manager.event;
 
+import seedu.manager.exception.ItemNotFoundException;
+
 import java.util.ArrayList;
 
 
@@ -8,6 +10,8 @@ import java.util.ArrayList;
  * It provides methods to manage an event list.
  */
 public class EventList  {
+    private static final String MISSING_EVENT_MESSAGE = "Event not found!";
+
     private final ArrayList<Event> eventList;
 
     /**
@@ -62,17 +66,17 @@ public class EventList  {
      * Removes an event from the event list by its name.
      *
      * @param eventName the name of the event to be removed.
-     * @return {@code true} if the event was successfully removed;
-     *         {@code false} if no event with the specified name was found.
+     * @throws ItemNotFoundException if no event with the specified name was found.
      */
-    public boolean removeEvent(String eventName) {
+    public void removeEvent(String eventName) throws ItemNotFoundException {
         for (Event event : eventList) {
             if (event.getEventName().equals(eventName)) {
                 eventList.remove(event);
-                return true; // Event found and removed
+                return;
             }
         }
-        return false; // Event not found
+
+        throw new ItemNotFoundException(MISSING_EVENT_MESSAGE);
     }
 
     /**
@@ -97,21 +101,21 @@ public class EventList  {
      * This method searches for the event with the given name in the event list and
      * attempts to remove the specified participant from that event. If the event is
      * found and the participant is successfully removed, it returns {@code true}.
-     * If the event does not exist or the participant is not found, it returns
-     * {@code false}.
+     * If the event does not exist or the participant is not found, it throws an
+     * {@link ItemNotFoundException}.
      * </p>
      *
      * @param participantName the name of the participant to be removed from the event.
      * @param eventName      the name of the event from which the participant will be removed.
-     * @return {@code true} if the participant was successfully removed;
-     *         {@code false} if the event does not exist or the participant was not found.
+     * @throws ItemNotFoundException if the event does not exist or the participant was not found.
      */
-    public boolean removeParticipantFromEvent(String participantName, String eventName) {
+    public void removeParticipantFromEvent(String participantName, String eventName) throws ItemNotFoundException {
         for (Event event : eventList) {
             if (event.getEventName().equals(eventName)) {
-                return event.removeParticipant(participantName);
+                event.removeParticipant(participantName);
+                return;
             }
         }
-        return false;
+        throw new ItemNotFoundException(MISSING_EVENT_MESSAGE);
     }
 }

--- a/src/main/java/seedu/manager/event/EventList.java
+++ b/src/main/java/seedu/manager/event/EventList.java
@@ -63,6 +63,24 @@ public class EventList  {
     }
 
     /**
+     * Returns an event in the event list with the specified name.
+     * If the event is not in the list, throws a {@link ItemNotFoundException} with an error message
+     *
+     * @param eventName the name of the event
+     * @return the event in the event list with the specified name
+     * @throws ItemNotFoundException if the event is not in the event list
+     */
+    public Event getEventByName(String eventName) throws ItemNotFoundException {
+        for (Event event : eventList) {
+            if (event.getEventName().equals(eventName)) {
+                return event;
+            }
+        }
+
+        throw new ItemNotFoundException(MISSING_EVENT_MESSAGE);
+    }
+
+    /**
      * Removes an event from the event list by its name.
      *
      * @param eventName the name of the event to be removed.

--- a/src/main/java/seedu/manager/exception/ItemNotFoundException.java
+++ b/src/main/java/seedu/manager/exception/ItemNotFoundException.java
@@ -1,0 +1,13 @@
+package seedu.manager.exception;
+
+/**
+ * Signals that the specified item was not found in a given list
+ */
+public class ItemNotFoundException extends Exception {
+  /**
+   * @param message relevant information on the type of item that was not found
+   */
+  public ItemNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/seedu/manager/exception/ItemNotFoundException.java
+++ b/src/main/java/seedu/manager/exception/ItemNotFoundException.java
@@ -4,10 +4,10 @@ package seedu.manager.exception;
  * Signals that the specified item was not found in a given list
  */
 public class ItemNotFoundException extends Exception {
-  /**
-   * @param message relevant information on the type of item that was not found
-   */
-  public ItemNotFoundException(String message) {
+    /**
+    * @param message relevant information on the type of item that was not found
+    */
+    public ItemNotFoundException(String message) {
         super(message);
     }
 }

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -24,6 +24,10 @@ public class Parser {
             Please enter your commands in the following format:
             remove -e EVENT_NAME
             remove -p PARTICIPANT_NAME -e EVENT_NAME""";
+    private static final String INVALID_VIEW_MESSAGE = """
+            Invalid command!
+            Please enter your commands in the following format:
+            view -e EVENT_NAME""";
 
     /**
      * Returns a command based on the given user command string
@@ -147,9 +151,9 @@ public class Parser {
                 return new ViewCommand(inputParts[1].trim());
             }
 
-            return new InvalidCommand(INVALID_REMOVE_MESSAGE);
+            return new InvalidCommand(INVALID_VIEW_MESSAGE);
         } catch (IndexOutOfBoundsException exception) {
-            return new InvalidCommand(INVALID_REMOVE_MESSAGE);
+            return new InvalidCommand(INVALID_VIEW_MESSAGE);
         }
     }
 }

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -72,10 +72,10 @@ public class Parser {
 
             if (commandFlag.equals("-e")) {
                 inputParts = input.split("(-e|-t|-v)");
-                return new AddCommand(inputParts[1], inputParts[2], inputParts[3]);
+                return new AddCommand(inputParts[1].trim(), inputParts[2].trim(), inputParts[3].trim());
             } else if (commandFlag.equals("-p")) {
                 inputParts = input.split("(-p|-e)");
-                return new AddCommand(inputParts[1], inputParts[2]);
+                return new AddCommand(inputParts[1].trim(), inputParts[2].trim());
             }
 
             return new InvalidCommand(INVALID_ADD_MESSAGE);
@@ -107,10 +107,10 @@ public class Parser {
 
             if (commandFlag.equals("-e")) {
                 inputParts = input.split("-e");
-                return new RemoveCommand(inputParts[1]);
+                return new RemoveCommand(inputParts[1].trim());
             } else if (commandFlag.equals("-p")) {
                 inputParts = input.split("(-p|-e)");
-                return new RemoveCommand(inputParts[1], inputParts[2]);
+                return new RemoveCommand(inputParts[1].trim(), inputParts[2].trim());
             }
 
             return new InvalidCommand(INVALID_REMOVE_MESSAGE);

--- a/src/test/java/seedu/manager/command/RemoveCommandTest.java
+++ b/src/test/java/seedu/manager/command/RemoveCommandTest.java
@@ -2,13 +2,14 @@ package seedu.manager.command;
 
 import org.junit.jupiter.api.Test;
 import seedu.manager.event.EventList;
+import seedu.manager.exception.ItemNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RemoveCommandTest {
 
     @Test
-    public void remove_oneParticipant_success() {
+    public void remove_oneParticipant_success() throws ItemNotFoundException {
         EventList eventList = new EventList();
 
         eventList.addEvent("Event 1", "2024-10-10 10:00", "Venue A");
@@ -20,7 +21,7 @@ public class RemoveCommandTest {
     }
 
     @Test
-    public void remove_oneParticipantWrongly_success() {
+    public void remove_oneParticipantWrongly_success() throws ItemNotFoundException {
         EventList eventList = new EventList();
 
         eventList.addEvent("Event 1", "2024-10-10 10:00", "Venue A");

--- a/src/test/java/seedu/manager/command/RemoveCommandTest.java
+++ b/src/test/java/seedu/manager/command/RemoveCommandTest.java
@@ -22,7 +22,7 @@ public class RemoveCommandTest {
     }
 
     @Test
-    public void remove_oneParticipantWrongly_throwException() throws ItemNotFoundException {
+    public void remove_oneParticipantWrongly_throwException() {
         EventList eventList = new EventList();
 
         eventList.addEvent("Event 1", "2024-10-10 10:00", "Venue A");
@@ -44,7 +44,7 @@ public class RemoveCommandTest {
     }
 
     @Test
-    public void remove_invalidEvent_throwsException() throws ItemNotFoundException {
+    public void remove_invalidEvent_throwsException() {
         EventList eventList = new EventList();
 
         assertThrows(ItemNotFoundException.class, () -> {eventList.removeEvent("Event 2");});

--- a/src/test/java/seedu/manager/command/RemoveCommandTest.java
+++ b/src/test/java/seedu/manager/command/RemoveCommandTest.java
@@ -5,6 +5,7 @@ import seedu.manager.event.EventList;
 import seedu.manager.exception.ItemNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RemoveCommandTest {
 
@@ -21,14 +22,31 @@ public class RemoveCommandTest {
     }
 
     @Test
-    public void remove_oneParticipantWrongly_success() throws ItemNotFoundException {
+    public void remove_oneParticipantWrongly_throwException() throws ItemNotFoundException {
         EventList eventList = new EventList();
 
         eventList.addEvent("Event 1", "2024-10-10 10:00", "Venue A");
         eventList.addParticipantToEvent("Tom", "Event 1");
         eventList.addParticipantToEvent("Harry", "Event 1");
-        eventList.removeParticipantFromEvent("Tom", "Event 2");
 
-        assertEquals(2, eventList.getEvent(0).getParticipantCount());
+        assertThrows(ItemNotFoundException.class, () -> {eventList.removeParticipantFromEvent("Tom", "Event 2");});
+    }
+
+    @Test
+    public void remove_oneEvent_success() throws ItemNotFoundException {
+        EventList eventList = new EventList();
+
+        eventList.addEvent("Event 1", "2024-10-10 10:00", "Venue A");
+        eventList.addEvent("Event 2", "2024-10-31 21:00", "Venue B");
+        eventList.removeEvent("Event 2");
+
+        assertEquals(eventList.getListSize(), 1);
+    }
+
+    @Test
+    public void remove_invalidEvent_throwsException() throws ItemNotFoundException {
+        EventList eventList = new EventList();
+
+        assertThrows(ItemNotFoundException.class, () -> {eventList.removeEvent("Event 2");});
     }
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -21,7 +21,7 @@ add -p PARTICIPANT_NAME -e EVENT_NAME
 Enter a command: Event added successfully
 ------------------------
 Enter a command: There are 1 events in your list! Here are your scheduled events:
-1. Event name:  dinner party / Event time:  2024-10-10 / Event venue:  Alice's House
+1. Event name: dinner party/ Event time: 2024-10-10/ Event venue: Alice's House
 
 ------------------------
 Enter a command: Thank you for using EventManagerCLI. Goodbye!


### PR DESCRIPTION
The added exception is thrown when an event or participant that is not in the list is parsed for (in a remove command). A different error message is printed for a missing event or missing participant.

Fixes #59 