### PR TITLE
Integrate CommandOutput class into Command class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bin/
 
 /text-ui-test/ACTUAL.TXT
 text-ui-test/EXPECTED-UNIX.TXT
+src/main/java/META-INF/MANIFEST.MF

--- a/src/main/java/seedu/manager/Main.java
+++ b/src/main/java/seedu/manager/Main.java
@@ -1,7 +1,6 @@
 package seedu.manager;
 
 import seedu.manager.command.Command;
-import seedu.manager.command.CommandOutput;
 import seedu.manager.event.EventList;
 import seedu.manager.parser.Parser;
 import seedu.manager.ui.Ui;

--- a/src/main/java/seedu/manager/Main.java
+++ b/src/main/java/seedu/manager/Main.java
@@ -31,10 +31,10 @@ public class Main {
             String userCommandText = ui.getCommand();
             command = new Parser().parseCommand(userCommandText);
             command.setData(events);
-            CommandOutput output = command.execute();
-            ui.showOutputToUser(output);
+            command.execute();
+            ui.showOutputToUser(command);
 
-            isGettingCommands = !output.getCanExit();
+            isGettingCommands = !command.getCanExit();
         }
     }
 }

--- a/src/main/java/seedu/manager/command/AddCommand.java
+++ b/src/main/java/seedu/manager/command/AddCommand.java
@@ -21,6 +21,7 @@ public class AddCommand extends Command {
      * @param venue The venue of the event to be added.
      */
     public AddCommand(String eventName, String time, String venue) {
+        super(false);
         this.eventName = eventName;
         this.time = time;
         this.venue = venue;
@@ -35,6 +36,7 @@ public class AddCommand extends Command {
      *                       or the event to be created if no participant name is provided.
      */
     public AddCommand(String participantName, String eventName) {
+        super(false);
         this.participantName = participantName;
         this.eventName = eventName;
     }
@@ -47,18 +49,15 @@ public class AddCommand extends Command {
      * If a participant name is provided, it will add the participant to the
      * specified event in the event list.
      * </p>
-     *
-     * @return a {@link CommandOutput} object containing a message about the result of the execution.
-     *     The message indicates whether an event or participant was successfully added.
      */
     @Override
-    public CommandOutput execute() {
+    public void execute() {
         if (participantName == null) {
             this.eventList.addEvent(this.eventName, this.time, this.venue);
-            return new CommandOutput(ADD_EVENT_MESSAGE, false);
+            this.message = ADD_EVENT_MESSAGE;
         } else {
             this.eventList.addParticipantToEvent(this.participantName, this.eventName);
-            return new CommandOutput(ADD_PARTICIPANT_MESSAGE, false);
+            this.message = ADD_PARTICIPANT_MESSAGE;
         }
     }
 }

--- a/src/main/java/seedu/manager/command/Command.java
+++ b/src/main/java/seedu/manager/command/Command.java
@@ -7,13 +7,47 @@ import seedu.manager.event.EventList;
  */
 public abstract class Command {
     protected EventList eventList;
+    protected String message;
+    protected boolean canExit;
 
+    /**
+     * Constructs a new Command with whether the program can be exited from
+     *
+     * @param canExit whether the program can be exited from
+     */
+    protected Command(boolean canExit) {
+        this.canExit = canExit;
+    }
+
+    /**
+     * Sets the command's event list to a specified event list
+     *
+     * @param events the specified event list
+     */
     public void setData(EventList events) {
         this.eventList = events;
     }
 
     /**
-     * Returns the output of the executable command
+     * Executes the command
      */
-    public abstract CommandOutput execute();
+    public abstract void execute();
+
+    /**
+     * Returns the command's message
+     *
+     * @return the command's message
+     */
+    public String getMessage() {
+        return this.message;
+    }
+
+    /**
+     * Returns true if the program can be exited from, returns false otherwise
+     *
+     * @return true if the program can be exited from, false otherwise
+     */
+    public boolean getCanExit() {
+        return canExit;
+    }
 }

--- a/src/main/java/seedu/manager/command/ExitCommand.java
+++ b/src/main/java/seedu/manager/command/ExitCommand.java
@@ -8,11 +8,16 @@ public class ExitCommand extends Command {
     private static final String EXIT_MESSAGE = "Thank you for using EventManagerCLI. Goodbye!";
 
     /**
-     * Returns a command output with an exit message
-     *
-     * @return The command output with an exit message
+     * Constructs a new ExitCommand
      */
-    public CommandOutput execute() {
-        return new CommandOutput(EXIT_MESSAGE, true);
+    public ExitCommand() {
+        super(true);
+    }
+
+    /**
+     * Executes the exit command
+     */
+    public void execute() {
+        this.message = EXIT_MESSAGE;
     }
 }

--- a/src/main/java/seedu/manager/command/InvalidCommand.java
+++ b/src/main/java/seedu/manager/command/InvalidCommand.java
@@ -12,16 +12,15 @@ public class InvalidCommand extends Command {
      * @param errorMessage The specified error message
      */
     public InvalidCommand(String errorMessage) {
+        super(false);
         this.errorMessage = errorMessage;
     }
 
     /**
-     * Returns a new command output with the error message
-     *
-     * @return A command output with the error message
+     * Executes the invalid command
      */
     @Override
-    public CommandOutput execute() {
-        return new CommandOutput(this.errorMessage, false);
+    public void execute() {
+        this.message = this.errorMessage;
     }
 }

--- a/src/main/java/seedu/manager/command/ListCommand.java
+++ b/src/main/java/seedu/manager/command/ListCommand.java
@@ -7,16 +7,21 @@ public class ListCommand extends Command {
             "Here are your scheduled events:";
 
     /**
-     * Returns a command output with a list message
-     *
-     * @return The command output with a list message
+     * Constructs a new ListCommand
      */
-    public CommandOutput execute() {
+    public ListCommand() {
+        super(false);
+    }
+
+    /**
+     * Executes the ListCommand by getting a list of all events
+     */
+    public void execute() {
         StringBuilder outputMessage = new StringBuilder(String.format(LIST_MESSAGE, eventList.getListSize()) + "\n");
         for (int i = 0; i < eventList.getListSize(); i++) {
             outputMessage.append(String.format("%d. %s\n", i + 1, eventList.getEvent(i).toString()));
         }
 
-        return new CommandOutput(outputMessage.toString(), false);
+        this.message = outputMessage.toString();
     }
 }

--- a/src/main/java/seedu/manager/command/MenuCommand.java
+++ b/src/main/java/seedu/manager/command/MenuCommand.java
@@ -16,12 +16,17 @@ public class MenuCommand extends Command {
             remove -p PARTICIPANT_NAME -e EVENT_NAME: Remove a participant from an event.""";
 
     /**
-     * Returns a command output with the menu message
-     *
-     * @return The command output with the menu message
+     * Constructs a new MenuCommand
+     */
+    public MenuCommand() {
+        super(false);
+    }
+
+    /**
+     * Executes the menu command
      */
     @Override
-    public CommandOutput execute() {
-        return new CommandOutput(MENU_MESSAGE, false);
+    public void execute() {
+       this.message = MENU_MESSAGE;
     }
 }

--- a/src/main/java/seedu/manager/command/MenuCommand.java
+++ b/src/main/java/seedu/manager/command/MenuCommand.java
@@ -27,6 +27,6 @@ public class MenuCommand extends Command {
      */
     @Override
     public void execute() {
-       this.message = MENU_MESSAGE;
+        this.message = MENU_MESSAGE;
     }
 }

--- a/src/main/java/seedu/manager/command/RemoveCommand.java
+++ b/src/main/java/seedu/manager/command/RemoveCommand.java
@@ -17,6 +17,7 @@ public class RemoveCommand extends Command {
      * @param eventName The name of the event to be removed.
      */
     public RemoveCommand(String eventName) {
+        super(false);
         this.eventName = eventName;
     }
 
@@ -27,6 +28,7 @@ public class RemoveCommand extends Command {
      * @param participantName The name of the participant to be removed.
      */
     public RemoveCommand(String participantName, String eventName) {
+        super(false);
         this.eventName = eventName;
         this.participantName = participantName;
     }
@@ -37,15 +39,12 @@ public class RemoveCommand extends Command {
      * <p>
      * If no participant name is provided, this method attempts to remove the event
      * specified by the event name. If a participant name is provided, it tries to
-     * remove that participant from the specified event. The result of the operation
-     * is indicated by the return value.
+     * remove that participant from the specified event. The command's message is then
+     * set depending on whether the removal was successful or failed.
      * </p>
-     *
-     * @return a {@link CommandOutput} object containing a message indicating
-     *     whether the removal was successful or failed.
      */
     @Override
-    public CommandOutput execute() {
+    public void execute() {
         boolean isRemoved;
 
         if (participantName == null) {
@@ -55,9 +54,9 @@ public class RemoveCommand extends Command {
         }
 
         if (isRemoved) {
-            return new CommandOutput(REMOVE_SUCCESS, false);
+            this.message = REMOVE_SUCCESS;
         } else {
-            return new CommandOutput(REMOVE_FAILURE, false);
+            this.message = REMOVE_FAILURE;
         }
     }
 }

--- a/src/main/java/seedu/manager/command/ViewCommand.java
+++ b/src/main/java/seedu/manager/command/ViewCommand.java
@@ -22,15 +22,14 @@ public class ViewCommand extends Command {
      * @param eventName The name of the event to be viewed.
      */
     public ViewCommand(String eventName) {
+        super(false);
         this.eventName = eventName;
     }
 
     /**
-     * Returns a command output with a view message
-     *
-     * @return The command output with a view message
+     * Executes the command to view the participants for an event.
      */
-    public CommandOutput execute() {
+    public void execute() {
         Optional<Event> eventToView = eventList.getEventByName(this.eventName);
 
         if (eventToView.isPresent()) {
@@ -42,9 +41,9 @@ public class ViewCommand extends Command {
                 count++;
             }
 
-            return new CommandOutput(outputMessage.toString(), false);
+            this.message = outputMessage.toString();
         } else {
-            return new CommandOutput(INVALID_EVENT_MESSAGE, false);
+            this.message = INVALID_EVENT_MESSAGE;
         }
     }
 }

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -1,6 +1,5 @@
 package seedu.manager.parser;
 
-import seedu.manager.Main;
 import seedu.manager.command.Command;
 import seedu.manager.command.AddCommand;
 import seedu.manager.command.InvalidCommand;
@@ -12,7 +11,6 @@ import seedu.manager.command.ViewCommand;
 
 import java.util.logging.Logger;
 
-import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 
 /**

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -1,5 +1,6 @@
 package seedu.manager.parser;
 
+import seedu.manager.Main;
 import seedu.manager.command.Command;
 import seedu.manager.command.AddCommand;
 import seedu.manager.command.InvalidCommand;
@@ -9,10 +10,16 @@ import seedu.manager.command.MenuCommand;
 import seedu.manager.command.ListCommand;
 import seedu.manager.command.ViewCommand;
 
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
+
 /**
  * Represents the command parser for EventManagerCLI
  */
 public class Parser {
+    private static final Logger logger = Logger.getLogger(Parser.class.getName());
     private static final String INVALID_COMMAND_MESSAGE = "Invalid command!";
     private static final String INVALID_ADD_MESSAGE = """
             Invalid command!
@@ -87,8 +94,10 @@ public class Parser {
                 return new AddCommand(inputParts[1].trim(), inputParts[2].trim());
             }
 
+            logger.log(WARNING,"Invalid command format");
             return new InvalidCommand(INVALID_ADD_MESSAGE);
         } catch (IndexOutOfBoundsException exception) {
+            logger.log(WARNING,"Invalid command format");
             return new InvalidCommand(INVALID_ADD_MESSAGE);
         }
     }
@@ -122,8 +131,10 @@ public class Parser {
                 return new RemoveCommand(inputParts[1].trim(), inputParts[2].trim());
             }
 
+            logger.log(WARNING,"Invalid command format");
             return new InvalidCommand(INVALID_REMOVE_MESSAGE);
         } catch (IndexOutOfBoundsException exception) {
+            logger.log(WARNING,"Invalid command format");
             return new InvalidCommand(INVALID_REMOVE_MESSAGE);
         }
     }
@@ -152,8 +163,10 @@ public class Parser {
                 return new ViewCommand(inputParts[1].trim());
             }
 
+            logger.log(WARNING,"Invalid command format");
             return new InvalidCommand(INVALID_VIEW_MESSAGE);
         } catch (IndexOutOfBoundsException exception) {
+            logger.log(WARNING,"Invalid command format");
             return new InvalidCommand(INVALID_VIEW_MESSAGE);
         }
     }

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -74,6 +74,7 @@ public class Parser {
      * @return a {@link Command} object representing the parsed command.
      */
     public Command parseAddCommand(String input, String[] commandParts) {
+        assert commandParts[0].equalsIgnoreCase(AddCommand.COMMAND_WORD);
         try {
             String commandFlag = commandParts[1];
             String[] inputParts;

--- a/src/main/java/seedu/manager/ui/Ui.java
+++ b/src/main/java/seedu/manager/ui/Ui.java
@@ -1,7 +1,6 @@
 package seedu.manager.ui;
 
 import seedu.manager.command.Command;
-import seedu.manager.command.CommandOutput;
 
 import java.util.Scanner;
 

--- a/src/main/java/seedu/manager/ui/Ui.java
+++ b/src/main/java/seedu/manager/ui/Ui.java
@@ -1,5 +1,6 @@
 package seedu.manager.ui;
 
+import seedu.manager.command.Command;
 import seedu.manager.command.CommandOutput;
 
 import java.util.Scanner;
@@ -37,10 +38,10 @@ public class Ui {
     }
 
     /**
-     * show the output of command to the users.
+     * show the output message a of command to the users.
      */
-    public void showOutputToUser(CommandOutput output){
-        System.out.println(output.getMessage());
+    public void showOutputToUser(Command command){
+        System.out.println(command.getMessage());
         System.out.println(SEPARATOR);
     }
 }

--- a/src/test/java/seedu/manager/command/ListCommandTest.java
+++ b/src/test/java/seedu/manager/command/ListCommandTest.java
@@ -20,17 +20,16 @@ public class ListCommandTest {
 
         listCommand = new ListCommand();
         listCommand.setData(eventList);
+        listCommand.execute();
     }
 
     @Test
     public void execute_twoEvents_success() {
-        CommandOutput result = listCommand.execute();
-
         String expectedMessage = "There are 2 events in your list! Here are your scheduled events:\n"
                 + "1. Event name: Event 1 / Event time: 2024-10-10 10:00 / Event venue: Venue A\n"
                 + "2. Event name: Event 2 / Event time: 2024-11-11 12:00 / Event venue: Venue B\n";
 
-        assertEquals(expectedMessage, result.getMessage());
-        assertFalse(result.getCanExit());
+        assertEquals(expectedMessage, listCommand.getMessage());
+        assertFalse(listCommand.getCanExit());
     }
 }

--- a/src/test/java/seedu/manager/command/ViewCommandTest.java
+++ b/src/test/java/seedu/manager/command/ViewCommandTest.java
@@ -27,16 +27,15 @@ public class ViewCommandTest {
 
         viewCommand = new Parser().parseCommand("view -e Event 1");
         viewCommand.setData(eventList);
+        viewCommand.execute();
     }
 
     @Test
     public void execute_twoEvents_success() {
-        CommandOutput result = viewCommand.execute();
-
         String expectedMessage = "There are 1 participants in Event 1! Here are your participants:\n"
                 + "1. Tom\n";
 
-        assertEquals(expectedMessage, result.getMessage());
-        assertFalse(result.getCanExit());
+        assertEquals(expectedMessage, viewCommand.getMessage());
+        assertFalse(viewCommand.getCanExit());
     }
 }


### PR DESCRIPTION
Fixes #64 

The functionality of the CommandOutput class (with the same methods) is now done in the Command class. For every Command child class, execute() has to be called before getting the output message.