### PR TITLE
Add a "mark" command to mark events as completed

### DIFF
--- a/src/main/java/seedu/manager/command/MarkCommand.java
+++ b/src/main/java/seedu/manager/command/MarkCommand.java
@@ -11,30 +11,34 @@ public class MarkCommand extends Command {
     public static final String COMMAND_WORD = "mark";
 
     private static final String EVENT_MARK_MESSAGE = "Event marked as done";
+    private static final String EVENT_UNMARK_MESSAGE = "Event marked not done";
     private static final String INVALID_EVENT_MESSAGE = "Event not found!";
 
     private String eventName;
+    private boolean toMark;
 
     /**
      * Constructs a new MarkCommand with the given event name
      *
      * @param eventName the given event name
      */
-    public MarkCommand(String eventName) {
+    public MarkCommand(String eventName, boolean toMark) {
         super(false);
         this.eventName = eventName;
+        this.toMark = toMark;
     }
 
     /**
-     * Executes a mark command by marking the specified event as done
+     * Executes a mark command by marking the specified event as done or not done,
+     * depending on the value of toMark.
      */
     @Override
     public void execute() {
         Optional<Event> eventToMark = this.eventList.getEventByName(this.eventName);
 
         if (eventToMark.isPresent()) {
-            eventToMark.get().setDone(true);
-            this.message = EVENT_MARK_MESSAGE;
+            eventToMark.get().setDone(this.toMark);
+            this.message = (this.toMark) ? EVENT_MARK_MESSAGE : EVENT_UNMARK_MESSAGE;
         } else {
             this.message = INVALID_EVENT_MESSAGE;
         }

--- a/src/main/java/seedu/manager/command/MarkCommand.java
+++ b/src/main/java/seedu/manager/command/MarkCommand.java
@@ -1,0 +1,42 @@
+package seedu.manager.command;
+
+import seedu.manager.event.Event;
+
+import java.util.Optional;
+
+/**
+ * Represents an executable mark command
+ */
+public class MarkCommand extends Command {
+    public static final String COMMAND_WORD = "mark";
+
+    private static final String EVENT_MARK_MESSAGE = "Event marked as done";
+    private static final String INVALID_EVENT_MESSAGE = "Event not found!";
+
+    private String eventName;
+
+    /**
+     * Constructs a new MarkCommand with the given event name
+     *
+     * @param eventName the given event name
+     */
+    public MarkCommand(String eventName) {
+        super(false);
+        this.eventName = eventName;
+    }
+
+    /**
+     * Executes a mark command by marking the specified event as done
+     */
+    @Override
+    public void execute() {
+        Optional<Event> eventToMark = this.eventList.getEventByName(this.eventName);
+
+        if (eventToMark.isPresent()) {
+            eventToMark.get().setDone(true);
+            this.message = EVENT_MARK_MESSAGE;
+        } else {
+            this.message = INVALID_EVENT_MESSAGE;
+        }
+    }
+}

--- a/src/main/java/seedu/manager/event/Event.java
+++ b/src/main/java/seedu/manager/event/Event.java
@@ -147,6 +147,7 @@ public class Event {
      */
     @Override
     public String toString(){
-        return "Event name: " + eventName + " / Event time: " + eventTime + " / Event venue: " + eventVenue;
+        return String.format("Event name: %s / Event time: %s / Event venue: %s / Done: %c", eventName, eventTime,
+                eventVenue, markIfDone());
     }
 }

--- a/src/main/java/seedu/manager/event/Event.java
+++ b/src/main/java/seedu/manager/event/Event.java
@@ -11,6 +11,7 @@ public class Event {
     private final String eventName;
     private String eventTime;
     private String eventVenue;
+    private boolean isDone;
 
     /**
      * Constructs an Event with the specified name.
@@ -34,6 +35,7 @@ public class Event {
         this.eventTime = eventTime;
         this.eventVenue = eventVenue;
         this.participantList = new ArrayList<>();
+        this.isDone = false;
     }
 
     /**
@@ -98,6 +100,13 @@ public class Event {
     }
 
     /**
+     * @return true if the event is marked done, false otherwise
+     */
+    public boolean isDone() {
+        return isDone;
+    }
+
+    /**
      * Sets a new time for the event.
      *
      * @param eventTime the new event time
@@ -113,6 +122,22 @@ public class Event {
      */
     public void setEventVenue(String eventVenue) {
         this.eventVenue = eventVenue;
+    }
+
+    /**
+     * Sets if the event is done or not done
+     *
+     * @param isDone if the event is done
+     */
+    public void setDone(boolean isDone) {
+        this.isDone = isDone;
+    }
+
+    /**
+     * @return 'Y' if event is marked done, 'N' otherwise
+     */
+    public char markIfDone() {
+        return (this.isDone) ? 'Y' : 'N';
     }
 
     /**

--- a/src/test/java/seedu/manager/command/ListCommandTest.java
+++ b/src/test/java/seedu/manager/command/ListCommandTest.java
@@ -26,8 +26,8 @@ public class ListCommandTest {
     @Test
     public void execute_twoEvents_success() {
         String expectedMessage = "There are 2 events in your list! Here are your scheduled events:\n"
-                + "1. Event name: Event 1 / Event time: 2024-10-10 10:00 / Event venue: Venue A\n"
-                + "2. Event name: Event 2 / Event time: 2024-11-11 12:00 / Event venue: Venue B\n";
+                + "1. Event name: Event 1 / Event time: 2024-10-10 10:00 / Event venue: Venue A / Done: N\n"
+                + "2. Event name: Event 2 / Event time: 2024-11-11 12:00 / Event venue: Venue B / Done: N\n";
 
         assertEquals(expectedMessage, listCommand.getMessage());
         assertFalse(listCommand.getCanExit());

--- a/src/test/java/seedu/manager/command/MarkCommandTest.java
+++ b/src/test/java/seedu/manager/command/MarkCommandTest.java
@@ -16,18 +16,29 @@ class MarkCommandTest {
     }
 
     @Test
-    public void execute_eventPresent_success() {
-        MarkCommand command = new MarkCommand("Event 1");
+    public void execute_eventPresentMarkDone_success() {
+        String expectedMessage = "Event marked as done";
+        MarkCommand command = new MarkCommand("Event 1", true);
         command.setData(eventList);
         command.execute();
-        assertEquals("Event marked as done", command.getMessage());
+        assertEquals(expectedMessage, command.getMessage());
+    }
+
+    @Test
+    public void execute_eventPresentMarkNotDone_success() {
+        String expectedMessage = "Event marked not done";
+        MarkCommand command = new MarkCommand("Event 1", false);
+        command.setData(eventList);
+        command.execute();
+        assertEquals(expectedMessage, command.getMessage());
     }
 
     @Test
     public void execute_eventAbsent_failure() {
-        MarkCommand command = new MarkCommand("Event 2");
+        String expectedMessage = "Event not found!";
+        MarkCommand command = new MarkCommand("Event 2", true);
         command.setData(eventList);
         command.execute();
-        assertEquals("Event not found!", command.getMessage());
+        assertEquals(expectedMessage, command.getMessage());
     }
 }

--- a/src/test/java/seedu/manager/command/MarkCommandTest.java
+++ b/src/test/java/seedu/manager/command/MarkCommandTest.java
@@ -1,0 +1,33 @@
+package seedu.manager.command;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.manager.event.EventList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MarkCommandTest {
+    private EventList eventList;
+
+    @BeforeEach
+    public void testSetUp() {
+        eventList = new EventList();
+        eventList.addEvent("Event 1", "2024-10-10 1600", "Venue 1");
+    }
+
+    @Test
+    public void execute_eventPresent_success() {
+        MarkCommand command = new MarkCommand("Event 1");
+        command.setData(eventList);
+        command.execute();
+        assertEquals("Event marked as done", command.getMessage());
+    }
+
+    @Test
+    public void execute_eventAbsent_failure() {
+        MarkCommand command = new MarkCommand("Event 2");
+        command.setData(eventList);
+        command.execute();
+        assertEquals("Event not found!", command.getMessage());
+    }
+}

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -21,7 +21,7 @@ add -p PARTICIPANT_NAME -e EVENT_NAME
 Enter a command: Event added successfully
 ------------------------
 Enter a command: There are 1 events in your list! Here are your scheduled events:
-1. Event name: dinner party / Event time: 2024-10-10 / Event venue: Alice's House
+1. Event name: dinner party / Event time: 2024-10-10 / Event venue: Alice's House / Done: N
 
 ------------------------
 Enter a command: Thank you for using EventManagerCLI. Goodbye!


### PR DESCRIPTION
Fixes #68.

The "mark" command takes in an event and whether to mark the event as done or not done. The command's output message is then set if the event is successfully marked done or not done, or if it is not found.