### PR TITLE
Add support for the "mark" command to the parser

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -25,12 +25,12 @@ Shows a list of all valid user commands in the program.
 ```
 Here are the possible commands:
 
-add -e EVENT_NAME -t TIME -v VENUE: Add an event to the event list.
+add -e EVENT -t TIME -v VENUE: Add an event to the event list.
 list: List events.
-remove -e EVENT_NAME: Remove an event from the event list.
-add -p PARTICIPANT_NAME -e EVENT_NAME: Add a participant to an event.
-view -e EVENT_NAME: View the list of participants of an event.
-remove -p PARTICIPANT_NAME -e EVENT_NAME: Remove a participant from an event.
+remove -e EVENT: Remove an event from the event list.
+add -p PARTICIPANT -e EVENT: Add a participant to an event.
+view -e EVENT: View the list of participants of an event.
+remove -p PARTICIPANT -e EVENT: Remove a participant from an event.
 ```
 
 Format: `menu`
@@ -44,8 +44,8 @@ Format: `list`
 Adds an event to the event list, or a participant to an event.
 
 Format:  
-* `add -e EVENT_NAME -t TIME -v VENUE` for adding an event to the events list.
-* `add -p PARTICIPANT_NAME -e EVENT_NAME` for adding a participant to an event.
+* `add -e EVENT -t TIME -v VENUE` for adding an event to the events list.
+* `add -p PARTICIPANT -e EVENT` for adding a participant to an event.
 
 Examples:
 * `add -e Origami workshop -t Mon 1600-1800 -v Building A` adds an event with name `Origami workshop`,  
@@ -56,8 +56,8 @@ time `Mon 1600-1800` and venue `Building A` to the events list.
 Removes an event from the event list, or a participant from an event.
 
 Format:
-* `remove -e EVENT_NAME` for removing an event from the event list.
-* `remove -p PARTICIPANT_NAME -e EVENT_NAME` for removing a participant from an event.
+* `remove -e EVENT` for removing an event from the event list.
+* `remove -p PARTICIPANT -e EVENT` for removing a participant from an event.
 
 Examples:
 * `remove -e Origami workshop` removes the event `Origami workshop` from the event list.
@@ -66,7 +66,7 @@ Examples:
 ### View all participants for an event: `view`
 Shows a list of all participants for an event.
 
-Format: `view -e EVENT_NAME`
+Format: `view -e EVENT`
 
 Examples:
 * `view -e Origami workshop` shows a list of all participants for the event `Origami workshop`.
@@ -80,8 +80,8 @@ Format: `exit`
 
 * View all commands: `view`
 * List all events: `list`
-* Add event: `add -e EVENT_NAME -t TIME -v VENUE`
-* Add participant to an event: `add -p PARTICIPANT_NAME -e EVENT_NAME`
-* Remove event: `remove -e EVENT_NAME`
-* Remove participant from an event: `remove -p PARTICIPANT_NAME -e EVENT_NAME`
-* View all participants for an event: `view -e EVENT_NAME`
+* Add event: `add -e EVENT -t TIME -v VENUE`
+* Add participant to an event: `add -p PARTICIPANT -e EVENT`
+* Remove event: `remove -e EVENT`
+* Remove participant from an event: `remove -p PARTICIPANT -e EVENT`
+* View all participants for an event: `view -e EVENT`

--- a/src/main/java/seedu/manager/command/MarkCommand.java
+++ b/src/main/java/seedu/manager/command/MarkCommand.java
@@ -1,0 +1,46 @@
+package seedu.manager.command;
+
+import seedu.manager.event.Event;
+
+import java.util.Optional;
+
+/**
+ * Represents an executable mark command
+ */
+public class MarkCommand extends Command {
+    public static final String COMMAND_WORD = "mark";
+
+    private static final String EVENT_MARK_MESSAGE = "Event marked as done";
+    private static final String EVENT_UNMARK_MESSAGE = "Event marked not done";
+    private static final String INVALID_EVENT_MESSAGE = "Event not found!";
+
+    private String eventName;
+    private boolean toMark;
+
+    /**
+     * Constructs a new MarkCommand with the given event name
+     *
+     * @param eventName the given event name
+     */
+    public MarkCommand(String eventName, boolean toMark) {
+        super(false);
+        this.eventName = eventName;
+        this.toMark = toMark;
+    }
+
+    /**
+     * Executes a mark command by marking the specified event as done or not done,
+     * depending on the value of toMark.
+     */
+    @Override
+    public void execute() {
+        Optional<Event> eventToMark = this.eventList.getEventByName(this.eventName);
+
+        if (eventToMark.isPresent()) {
+            eventToMark.get().setDone(this.toMark);
+            this.message = (this.toMark) ? EVENT_MARK_MESSAGE : EVENT_UNMARK_MESSAGE;
+        } else {
+            this.message = INVALID_EVENT_MESSAGE;
+        }
+    }
+}

--- a/src/main/java/seedu/manager/command/MenuCommand.java
+++ b/src/main/java/seedu/manager/command/MenuCommand.java
@@ -13,7 +13,8 @@ public class MenuCommand extends Command {
             remove -e EVENT_NAME: Remove an event from the event list.
             add -p PARTICIPANT_NAME -e EVENT_NAME: Add a participant to an event.
             view -e EVENT_NAME: View the list of participants of an event.
-            remove -p PARTICIPANT_NAME -e EVENT_NAME: Remove a participant from an event.""";
+            remove -p PARTICIPANT_NAME -e EVENT_NAME: Remove a participant from an event.
+            mark -e EVENT -s STATUS: Mark an event as done or not done""";
 
     /**
      * Constructs a new MenuCommand

--- a/src/main/java/seedu/manager/command/MenuCommand.java
+++ b/src/main/java/seedu/manager/command/MenuCommand.java
@@ -8,12 +8,12 @@ public class MenuCommand extends Command {
     private static final String MENU_MESSAGE = """
             Here are the possible commands:
            
-            add -e EVENT_NAME -t TIME -v VENUE: Add an event to the event list.
+            add -e EVENT -t TIME -v VENUE: Add an event to the event list.
             list: List events.
-            remove -e EVENT_NAME: Remove an event from the event list.
-            add -p PARTICIPANT_NAME -e EVENT_NAME: Add a participant to an event.
-            view -e EVENT_NAME: View the list of participants of an event.
-            remove -p PARTICIPANT_NAME -e EVENT_NAME: Remove a participant from an event.
+            remove -e EVENT: Remove an event from the event list.
+            add -p PARTICIPANT -e EVENT: Add a participant to an event.
+            view -e EVENT: View the list of participants of an event.
+            remove -p PARTICIPANT -e EVENT: Remove a participant from an event.
             mark -e EVENT -s STATUS: Mark an event as done or not done""";
 
     /**

--- a/src/main/java/seedu/manager/event/Event.java
+++ b/src/main/java/seedu/manager/event/Event.java
@@ -11,6 +11,7 @@ public class Event {
     private final String eventName;
     private String eventTime;
     private String eventVenue;
+    private boolean isDone;
 
     /**
      * Constructs an Event with the specified name.
@@ -34,6 +35,7 @@ public class Event {
         this.eventTime = eventTime;
         this.eventVenue = eventVenue;
         this.participantList = new ArrayList<>();
+        this.isDone = false;
     }
 
     /**
@@ -98,6 +100,13 @@ public class Event {
     }
 
     /**
+     * @return true if the event is marked done, false otherwise
+     */
+    public boolean isDone() {
+        return isDone;
+    }
+
+    /**
      * Sets a new time for the event.
      *
      * @param eventTime the new event time
@@ -116,12 +125,29 @@ public class Event {
     }
 
     /**
+     * Sets if the event is done or not done
+     *
+     * @param isDone if the event is done
+     */
+    public void setDone(boolean isDone) {
+        this.isDone = isDone;
+    }
+
+    /**
+     * @return 'Y' if event is marked done, 'N' otherwise
+     */
+    public char markIfDone() {
+        return (this.isDone) ? 'Y' : 'N';
+    }
+
+    /**
      * Returns a string representation of the event, indicating its name, time and venue.
      *
      * @return A string that shows the event's name, time and venue.
      */
     @Override
     public String toString(){
-        return "Event name: " + eventName + " / Event time: " + eventTime + " / Event venue: " + eventVenue;
+        return String.format("Event name: %s / Event time: %s / Event venue: %s / Done: %c", eventName, eventTime,
+                eventVenue, markIfDone());
     }
 }

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -191,9 +191,8 @@ public class Parser {
      * <p>
      * This method checks the command flag extracted from the command parts. If the command
      * flag is {@code "-e"}, it splits the input string to create a {@link MarkCommand}
-     * to mark an event done or undone. If the command flag is {@code "-p"}, it creates a
-     * {@link RemoveCommand} for removing a participant from an event. Otherwise, it returns
-     * an {@link InvalidCommand} with an error message.
+     * to mark an event done or undone. Otherwise, it returns an {@link InvalidCommand}
+     * with an error message.
      * </p>
      *
      * @param input        the input string containing the command details.

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -3,6 +3,7 @@ package seedu.manager.parser;
 import seedu.manager.command.Command;
 import seedu.manager.command.AddCommand;
 import seedu.manager.command.InvalidCommand;
+import seedu.manager.command.MarkCommand;
 import seedu.manager.command.RemoveCommand;
 import seedu.manager.command.ExitCommand;
 import seedu.manager.command.MenuCommand;
@@ -33,6 +34,14 @@ public class Parser {
             Invalid command!
             Please enter your commands in the following format:
             view -e EVENT_NAME""";
+    private static final String INVALID_MARK_MESSAGE = """
+            Invalid command!
+            Please enter your commands in the following format:
+            mark -e EVENT -s STATUS""";
+    private static final String INVALID_EVENT_STATUS_MESSAGE = """
+            Invalid event status!
+            Please set the event status as either "done" or "undone"
+            """;
 
     /**
      * Returns a command based on the given user command string
@@ -56,7 +65,8 @@ public class Parser {
             return new MenuCommand();
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
-
+        case MarkCommand.COMMAND_WORD:
+            return parseMarkCommand(command, commandParts);
         default:
             return new InvalidCommand(INVALID_COMMAND_MESSAGE);
         }
@@ -172,6 +182,60 @@ public class Parser {
         } catch (IndexOutOfBoundsException exception) {
             logger.log(WARNING,"Invalid command format");
             return new InvalidCommand(INVALID_VIEW_MESSAGE);
+        }
+    }
+
+    /**
+     * Parses the input string to create a {@link Command} based on the provided command parts.
+     *
+     * <p>
+     * This method checks the command flag extracted from the command parts. If the command
+     * flag is {@code "-e"}, it splits the input string to create a {@link MarkCommand}
+     * to mark an event done or undone. If the command flag is {@code "-p"}, it creates a
+     * {@link RemoveCommand} for removing a participant from an event. Otherwise, it returns
+     * an {@link InvalidCommand} with an error message.
+     * </p>
+     *
+     * @param input        the input string containing the command details.
+     * @param commandParts an array of strings representing the parsed command parts,
+     *                     where the second element is the command flag.
+     * @return a {@link Command} object representing the parsed command.
+     */
+    private Command parseMarkCommand(String input, String[] commandParts) {
+        assert commandParts[0].equalsIgnoreCase(MarkCommand.COMMAND_WORD);
+        try {
+            String commandFlag = commandParts[1];
+
+            if (commandFlag.equalsIgnoreCase("-e")) {
+                String[] inputParts = input.split("-e|-s");
+                return getMarkEventCommand(inputParts[1].trim(), inputParts[2].trim());
+            }
+
+            logger.log(WARNING,"Invalid command format");
+            return new InvalidCommand(INVALID_MARK_MESSAGE);
+        } catch (IndexOutOfBoundsException exception) {
+            logger.log(WARNING,"Invalid command format");
+            return new InvalidCommand(INVALID_MARK_MESSAGE);
+        }
+    }
+
+    /**
+     * Returns a {@link MarkCommand} with a given event name and status, or an
+     * {@link InvalidCommand} if the status is invalid
+     *
+     * @param eventName the given event name
+     * @param status the given event status
+     * @return a MarkCommand with a given event name and status, or an
+     *     InvalidCommand if the status is invalid
+     */
+    private Command getMarkEventCommand(String eventName, String status) {
+        if (status.equalsIgnoreCase("done")) {
+            return new MarkCommand(eventName, true);
+        } else if (status.equalsIgnoreCase("undone")) {
+            return new MarkCommand(eventName, false);
+        } else {
+            logger.log(WARNING,"Invalid status keyword");
+            return new InvalidCommand(INVALID_EVENT_STATUS_MESSAGE);
         }
     }
 }

--- a/src/main/java/seedu/manager/parser/Parser.java
+++ b/src/main/java/seedu/manager/parser/Parser.java
@@ -23,17 +23,17 @@ public class Parser {
     private static final String INVALID_ADD_MESSAGE = """
             Invalid command!
             Please enter your commands in the following format:
-            add -e EVENT_NAME -t TIME -v VENUE
-            add -p PARTICIPANT_NAME -e EVENT_NAME""";
+            add -e EVENT -t TIME -v VENUE
+            add -p PARTICIPANT -e EVENT""";
     private static final String INVALID_REMOVE_MESSAGE = """
             Invalid command!
             Please enter your commands in the following format:
-            remove -e EVENT_NAME
-            remove -p PARTICIPANT_NAME -e EVENT_NAME""";
+            remove -e EVENT
+            remove -p PARTICIPANT -e EVENT""";
     private static final String INVALID_VIEW_MESSAGE = """
             Invalid command!
             Please enter your commands in the following format:
-            view -e EVENT_NAME""";
+            view -e EVENT""";
     private static final String INVALID_MARK_MESSAGE = """
             Invalid command!
             Please enter your commands in the following format:

--- a/src/test/java/seedu/manager/command/ListCommandTest.java
+++ b/src/test/java/seedu/manager/command/ListCommandTest.java
@@ -26,8 +26,8 @@ public class ListCommandTest {
     @Test
     public void execute_twoEvents_success() {
         String expectedMessage = "There are 2 events in your list! Here are your scheduled events:\n"
-                + "1. Event name: Event 1 / Event time: 2024-10-10 10:00 / Event venue: Venue A\n"
-                + "2. Event name: Event 2 / Event time: 2024-11-11 12:00 / Event venue: Venue B\n";
+                + "1. Event name: Event 1 / Event time: 2024-10-10 10:00 / Event venue: Venue A / Done: N\n"
+                + "2. Event name: Event 2 / Event time: 2024-11-11 12:00 / Event venue: Venue B / Done: N\n";
 
         assertEquals(expectedMessage, listCommand.getMessage());
         assertFalse(listCommand.getCanExit());

--- a/src/test/java/seedu/manager/command/MarkCommandTest.java
+++ b/src/test/java/seedu/manager/command/MarkCommandTest.java
@@ -1,0 +1,44 @@
+package seedu.manager.command;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.manager.event.EventList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MarkCommandTest {
+    private EventList eventList;
+
+    @BeforeEach
+    public void testSetUp() {
+        eventList = new EventList();
+        eventList.addEvent("Event 1", "2024-10-10 1600", "Venue 1");
+    }
+
+    @Test
+    public void execute_eventPresentMarkDone_success() {
+        String expectedMessage = "Event marked as done";
+        MarkCommand command = new MarkCommand("Event 1", true);
+        command.setData(eventList);
+        command.execute();
+        assertEquals(expectedMessage, command.getMessage());
+    }
+
+    @Test
+    public void execute_eventPresentMarkNotDone_success() {
+        String expectedMessage = "Event marked not done";
+        MarkCommand command = new MarkCommand("Event 1", false);
+        command.setData(eventList);
+        command.execute();
+        assertEquals(expectedMessage, command.getMessage());
+    }
+
+    @Test
+    public void execute_eventAbsent_failure() {
+        String expectedMessage = "Event not found!";
+        MarkCommand command = new MarkCommand("Event 2", true);
+        command.setData(eventList);
+        command.execute();
+        assertEquals(expectedMessage, command.getMessage());
+    }
+}

--- a/src/test/java/seedu/manager/parser/ParserTest.java
+++ b/src/test/java/seedu/manager/parser/ParserTest.java
@@ -5,6 +5,7 @@ import seedu.manager.command.AddCommand;
 import seedu.manager.command.Command;
 import seedu.manager.command.ExitCommand;
 import seedu.manager.command.InvalidCommand;
+import seedu.manager.command.MarkCommand;
 import seedu.manager.command.MenuCommand;
 import seedu.manager.command.ListCommand;
 import seedu.manager.command.RemoveCommand;
@@ -73,6 +74,30 @@ class ParserTest {
     public void removeCommand_removeNoParameter_invalid() {
         Parser parser = new Parser();
         Command command = parser.parseCommand("remove");
+
+        assertInstanceOf(InvalidCommand.class, command);
+    }
+
+    @Test
+    public void parseCommand_markEvent_mark() {
+        Parser parser = new Parser();
+        Command command = parser.parseCommand("mark -e event -s done");
+
+        assertInstanceOf(MarkCommand.class, command);
+    }
+
+    @Test
+    public void parseCommand_markEventNoStatus_invalid() {
+        Parser parser = new Parser();
+        Command command = parser.parseCommand("mark -e event");
+
+        assertInstanceOf(InvalidCommand.class, command);
+    }
+
+    @Test
+    public void parseCommand_markEventInvalidStatus_invalid() {
+        Parser parser = new Parser();
+        Command command = parser.parseCommand("mark -e event -s yes");
 
         assertInstanceOf(InvalidCommand.class, command);
     }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -3,26 +3,35 @@ Enter a command: Invalid command!
 ------------------------
 Enter a command: Here are the possible commands:
 
-add -e EVENT_NAME -t TIME -v VENUE: Add an event to the event list.
+add -e EVENT -t TIME -v VENUE: Add an event to the event list.
 list: List events.
-remove -e EVENT_NAME: Remove an event from the event list.
-add -p PARTICIPANT_NAME -e EVENT_NAME: Add a participant to an event.
-view -e EVENT_NAME: View the list of participants of an event.
-remove -p PARTICIPANT_NAME -e EVENT_NAME: Remove a participant from an event.
+remove -e EVENT: Remove an event from the event list.
+add -p PARTICIPANT -e EVENT: Add a participant to an event.
+view -e EVENT: View the list of participants of an event.
+remove -p PARTICIPANT -e EVENT: Remove a participant from an event.
+mark -e EVENT -s STATUS: Mark an event as done or not done
 ------------------------
 Enter a command: There are 0 events in your list! Here are your scheduled events:
 
 ------------------------
 Enter a command: Invalid command!
 Please enter your commands in the following format:
-add -e EVENT_NAME -t TIME -v VENUE
-add -p PARTICIPANT_NAME -e EVENT_NAME
+add -e EVENT -t TIME -v VENUE
+add -p PARTICIPANT -e EVENT
 ------------------------
 Enter a command: Event added successfully
 ------------------------
 Enter a command: There are 1 events in your list! Here are your scheduled events:
 1. Event name: dinner party / Event time: 2024-10-10 / Event venue: Alice's House / Done: N
 
+------------------------
+Enter a command: Event marked as done
+------------------------
+Enter a command: There are 1 events in your list! Here are your scheduled events:
+1. Event name: dinner party / Event time: 2024-10-10 / Event venue: Alice's House / Done: Y
+
+------------------------
+Enter a command: Event not found!
 ------------------------
 Enter a command: Thank you for using EventManagerCLI. Goodbye!
 ------------------------

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -21,7 +21,7 @@ add -p PARTICIPANT_NAME -e EVENT_NAME
 Enter a command: Event added successfully
 ------------------------
 Enter a command: There are 1 events in your list! Here are your scheduled events:
-1. Event name: dinner party / Event time: 2024-10-10 / Event venue: Alice's House
+1. Event name: dinner party / Event time: 2024-10-10 / Event venue: Alice's House / Done: N
 
 ------------------------
 Enter a command: Thank you for using EventManagerCLI. Goodbye!

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -4,4 +4,7 @@ list
 add
 add -e dinner party -t 2024-10-10 -v Alice's House
 list
+mark -e dinner party -s done
+list
+mark -e Saturday brunch -s done
 exit


### PR DESCRIPTION
The "mark" command is called by the user by entering "mark -e EVENT -s STATUS", where the user specifies an event and status (done or undone). Depending on the input status, the parser then sets the mark command to mark the event either done or not done (undone).

Fixes #69.