### PR TITLE
Update user guide with information on "mark" command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -9,17 +9,23 @@ the participants and logistics of such events.
 
 1. Ensure that you have Java 17 or above installed.
 2. Down the latest version of `EventManagerCLI` from [here](https://github.com/AY2425S1-CS2113-W13-3/tp/releases).
-3. Open a new terminal in the folder that you put the JAR file in, and run the program with the  
-command ```java -jar EventManagerCLI.jar```.
+3. Open a new terminal in the folder that you put the JAR file in, and run the program with the command ```java -jar EventManagerCLI.jar```.
 The following message would be printed:
 ```
 Welcome to EventManagerCLI.
 Enter a command:
 ```
 
-## Features 
+## Features
+
+### Notes about the command format:
+
+* Words in `UPPER_CASE` represent parameters that are to be supplied by the user.
+* Parameters listed have to be entered in the specified order.
+* Extraneous parameters for commands that do not take in parameters (e.g. `list`) will be ignored.
 
 ### Viewing the command list: `menu`
+
 Shows a list of all valid user commands in the program.
 
 ```
@@ -36,64 +42,77 @@ remove -p PARTICIPANT -e EVENT: Remove a participant from an event.
 Format: `menu`
 
 ### List all events: `list`
+
 Shows a list of all events currently stored in the program.
 
 Format: `list`
 
 ### Add an event or participant: `add`
+
 Adds an event to the event list, or a participant to an event.
 
 Format:  
+
 * `add -e EVENT -t TIME -v VENUE` for adding an event to the events list.
 * `add -p PARTICIPANT -e EVENT` for adding a participant to an event.
 
 Examples:
-* `add -e Origami workshop -t Mon 1600-1800 -v Building A` adds an event with name `Origami workshop`,  
-time `Mon 1600-1800` and venue `Building A` to the events list.
+
+* `add -e Origami workshop -t Mon 1600-1800 -v Building A` adds an event with name `Origami workshop`, time `Mon 1600-1800` and venue `Building A` to the events list.
 * `add -p John Tan -e Origami workshop` adds a participant `John Tan` to the event `Origami workshop`.
 
 ### Remove an event or participant: `remove` 
+
 Removes an event from the event list, or a participant from an event.
 
 Format:
+
 * `remove -e EVENT` for removing an event from the event list.
 * `remove -p PARTICIPANT -e EVENT` for removing a participant from an event.
 
 Examples:
+
 * `remove -e Origami workshop` removes the event `Origami workshop` from the event list.
 * `remove -p John Tan -e Origami workshop` removes the participant `John Tan` from the event `Origami workshop`.
 
 ### View all participants for an event: `view`
+
 Shows a list of all participants for an event.
 
 Format: `view -e EVENT`
 
 Examples:
+
 * `view -e Origami workshop` shows a list of all participants for the event `Origami workshop`.
 
 ### Mark an event as done: `mark`
+
 Marks an event in the event list as done or not done.
 
 Format: `mark -e EVENT -s STATUS`
+
 * The status parameter must be either `done` (to mark done) or `undone` (to mark not done).
 
 Examples:
+
 * `mark -e Origami workshop -s done` marks the event `Origami workshop` as done.
 * `mark -e Origami workshop -s undone` marks the event `Origami workshop` as not done.
 
 ### Marks a participant as present: `mark`
+
 Marks a participant for an event as present or absent.
 
 Format: `mark -p PARTICIPANT -e EVENT -s STATUS`
+
 * The status parameter must be either `present` (to mark present) or `absent` (to mark absent).
 
 Examples:
-* `mark -p John Tan -e Origami workshop -s done` marks the participant `John Tan` in the `Origami workshop`  
-event as present.
-* `mark -p John Tan -e Origami workshop -s undone` marks the participant `John Tan` in the `Origami workshop`   
-event as absent.
+
+* `mark -p John Tan -e Origami workshop -s done` marks the participant `John Tan` in the `Origami workshop` event as present.
+* `mark -p John Tan -e Origami workshop -s undone` marks the participant `John Tan` in the `Origami workshop` event as absent.
 
 ### Exiting the program: `exit`
+
 Exits the program.
 
 Format: `exit`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -71,6 +71,28 @@ Format: `view -e EVENT`
 Examples:
 * `view -e Origami workshop` shows a list of all participants for the event `Origami workshop`.
 
+### Mark an event as done: `mark`
+Marks an event in the event list as done or not done.
+
+Format: `mark -e EVENT -s STATUS`
+* The status parameter must be either `done` (to mark done) or `undone` (to mark not done).
+
+Examples:
+* `mark -e Origami workshop -s done` marks the event `Origami workshop` as done.
+* `mark -e Origami workshop -s undone` marks the event `Origami workshop` as not done.
+
+### Marks a participant as present: `mark`
+Marks a participant for an event as present or absent.
+
+Format: `mark -p PARTICIPANT -e EVENT -s STATUS`
+* The status parameter must be either `present` (to mark present) or `absent` (to mark absent).
+
+Examples:
+* `mark -p John Tan -e Origami workshop -s done` marks the participant `John Tan` in the `Origami workshop`  
+event as present.
+* `mark -p John Tan -e Origami workshop -s undone` marks the participant `John Tan` in the `Origami workshop`   
+event as absent.
+
 ### Exiting the program: `exit`
 Exits the program.
 
@@ -85,3 +107,5 @@ Format: `exit`
 * Remove event: `remove -e EVENT`
 * Remove participant from an event: `remove -p PARTICIPANT -e EVENT`
 * View all participants for an event: `view -e EVENT`
+* Mark an event as done: `mark -e EVENT -s STATUS`
+* Mark a participant as present: `mark -p PARTICIPANT -e EVENT -s STATUS`


### PR DESCRIPTION
Added details on how to use the "mark" command, for both events and participants. The user guide has also been amended to follow the Markdown standard, and a "Notes on commands" section is included to guide users on how to interpret the command formats given.

Fixes #73.