### PR TITLE
Update copy command to reset mark status of participants in copied participant list.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -202,6 +202,7 @@ Copies the participant list from one event to another event.
 Format: `copy FROM_EVENT > TO_EVENT`
 
 * Both events must already exist.
+* The mark status of the `Participant`s in the copy participant list will be reset (i.e. set as absent).
 * If the event `TO_EVENT` already has an existing participant list, `TO_EVENT`'s participant list will be overwritten.
 
 Examples:

--- a/src/main/java/seedu/manager/command/CopyCommand.java
+++ b/src/main/java/seedu/manager/command/CopyCommand.java
@@ -90,8 +90,7 @@ public class CopyCommand extends Command {
         String name = participant.getName();
         String number = participant.getNumber();
         String email = participant.getEmail();
-        boolean isPresent = participant.isPresent();
 
-        return new Participant(name, number, email, isPresent);
+        return new Participant(name, number, email, false);
     }
 }

--- a/src/main/java/seedu/manager/item/Item.java
+++ b/src/main/java/seedu/manager/item/Item.java
@@ -37,14 +37,6 @@ public class Item {
         this.name = itemNewName;
     }
 
-    //@@author LTK-1606
-    /**
-     * @return {@code true} if isPresent is true, {@code false} otherwise.
-     */
-    public boolean isPresent() {
-        return isPresent;
-    }
-
     //@@author jemehgoh
     /**
      * Sets the item as present or not present.

--- a/src/test/java/seedu/manager/command/CopyCommandTest.java
+++ b/src/test/java/seedu/manager/command/CopyCommandTest.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+//@@author LTK-1606
 public class CopyCommandTest {
     EventList eventList = new EventList();
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
@@ -65,5 +66,4 @@ public class CopyCommandTest {
         assertEquals(expectedMessage, copyCommand.getMessage());
         assertFalse(copyCommand.getCanExit());
     }
-
 }


### PR DESCRIPTION
This PR modifies the copy command as above.

Fixes #205.